### PR TITLE
feat(tasks): Add --include-history flag to tasks list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ output: yaml  # or json
 - `--context-id`: Filter by context ID
 - `--limit`: Maximum number of tasks to return (default: 50)
 - `--offset`: Number of tasks to skip (default: 0)
+- `--include-history`: Include conversation history in the output (default: false)
 
 #### Task Get Options
 
@@ -236,6 +237,18 @@ $ a2a tasks list --state working --limit 5
    Status: working
    Message ID: msg-789
    Role: user
+```
+
+#### Include conversation history in task list
+
+By default, `tasks list` excludes conversation history to keep output manageable. Use `--include-history` to show complete task data:
+
+```bash
+# Without history (default - cleaner output)
+$ a2a tasks list --limit 1
+
+# With history (complete task data including conversation)
+$ a2a tasks list --limit 1 --include-history
 ```
 
 #### View detailed task information

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -113,6 +113,7 @@ func init() {
 	listTasksCmd.Flags().String("context-id", "", "Filter by context ID")
 	listTasksCmd.Flags().Int("limit", 50, "Maximum number of tasks to return")
 	listTasksCmd.Flags().Int("offset", 0, "Number of tasks to skip")
+	listTasksCmd.Flags().Bool("include-history", false, "Include conversation history in the output")
 	getTaskCmd.Flags().Int("history-length", 0, "Number of history messages to include")
 	submitTaskCmd.Flags().String("context-id", "", "Context ID for the task (optional, will generate new context if not provided)")
 	submitTaskCmd.Flags().String("task-id", "", "Task ID to resume (optional)")
@@ -350,6 +351,7 @@ var listTasksCmd = &cobra.Command{
 		contextID, _ := cmd.Flags().GetString("context-id")
 		limit, _ := cmd.Flags().GetInt("limit")
 		offset, _ := cmd.Flags().GetInt("offset")
+		includeHistory, _ := cmd.Flags().GetBool("include-history")
 
 		params := adk.TaskListParams{
 			Limit:  limit,
@@ -382,10 +384,31 @@ var listTasksCmd = &cobra.Command{
 			return fmt.Errorf("failed to unmarshal task list: %w", err)
 		}
 
+		// Filter out history if not requested
+		tasks := taskList.Tasks
+		if !includeHistory {
+			// Create new slice with tasks that have history removed
+			var filteredTasks []adk.Task
+			for _, task := range tasks {
+				// Create a copy of the task without history
+				filteredTask := adk.Task{
+					ID:        task.ID,
+					Kind:      task.Kind,
+					ContextID: task.ContextID,
+					Status:    task.Status,
+					Artifacts: task.Artifacts,
+					Metadata:  task.Metadata,
+					// History is intentionally omitted
+				}
+				filteredTasks = append(filteredTasks, filteredTask)
+			}
+			tasks = filteredTasks
+		}
+
 		output := map[string]any{
-			"tasks":   taskList.Tasks,
+			"tasks":   tasks,
 			"total":   taskList.Total,
-			"showing": len(taskList.Tasks),
+			"showing": len(tasks),
 		}
 
 		return printFormatted(output)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -384,13 +384,10 @@ var listTasksCmd = &cobra.Command{
 			return fmt.Errorf("failed to unmarshal task list: %w", err)
 		}
 
-		// Filter out history if not requested
 		tasks := taskList.Tasks
 		if !includeHistory {
-			// Create new slice with tasks that have history removed
 			var filteredTasks []adk.Task
 			for _, task := range tasks {
-				// Create a copy of the task without history
 				filteredTask := adk.Task{
 					ID:        task.ID,
 					Kind:      task.Kind,
@@ -398,7 +395,6 @@ var listTasksCmd = &cobra.Command{
 					Status:    task.Status,
 					Artifacts: task.Artifacts,
 					Metadata:  task.Metadata,
-					// History is intentionally omitted
 				}
 				filteredTasks = append(filteredTasks, filteredTask)
 			}


### PR DESCRIPTION
Implements the `--include-history` flag for the `tasks list` command to address issue #19.

## Changes
- Add `--include-history` flag to `a2a tasks list` command
- By default, task list now excludes conversation history for cleaner output
- Users can include history by adding the `--include-history` flag
- `tasks get <task-id>` continues to show full task details including history
- Updated README.md with documentation and examples

## Acceptance Criteria Met
- ✅ Flag `--include-history` added to `tasks list` command
- ✅ History shown only when flag is provided
- ✅ `tasks get <task-id>` still shows all details
- ✅ Feature is documented in README.md

Fixes #19

Generated with [Claude Code](https://claude.ai/code)